### PR TITLE
Add a gifv shortcode

### DIFF
--- a/layouts/shortcodes/gifv.html
+++ b/layouts/shortcodes/gifv.html
@@ -1,0 +1,19 @@
+<!-- Usage: {{< gifv "url|title" "url2|title" >}} -->
+<div class="columns">
+    {{ range $param := .Params }}
+    <!-- gifv -->
+    {{ $items := split $param "|" }}
+    {{ $src := (index $items 0) }}
+    {{ $title := (index $items 1) }}
+    <div class="column">
+        <video preload="auto" autoplay="autoplay" muted="muted" loop="loop" webkit-playsinline="">
+            <source src="{{ $src }}" type="video/mp4">
+            Your browser doesn't support mp4 video. :(
+        </video>
+
+        {{ if $title }}
+            <p class="has-text-centered is-italic has-text-grey-light">{{ $title }}</p>
+        {{ end }}
+    </div>
+    {{ end }}
+</div>


### PR DESCRIPTION
This adds a "gifv" (video) shortcode, allowing that content to also be displayed. This is otherwise identical to the image shortcode.