### PR TITLE
Add single title image shortcode

### DIFF
--- a/layouts/shortcodes/single-title-imgs.html
+++ b/layouts/shortcodes/single-title-imgs.html
@@ -1,0 +1,27 @@
+{{ $title := .Get 0 }}
+<div class="columns is-img-preview is-bottom-marginless">
+    {{ range $param := last (sub (len .Params) 1) .Params }}
+    <!-- image -->
+    {{ $items := split $param "|" }}
+    {{ $src := (index $items 0) }}
+    {{ $subtitle := (index $items 1) }}
+    {{ $split_src := split $src "." }}
+    {{ $extension := index $split_src (sub (len $split_src) 1) }}
+    <div class="column is-bottom-paddingless">
+        {{ if eq $extension "mp4" }}
+            <video preload="auto" autoplay="autoplay" muted="muted" loop="loop" webkit-playsinline="">
+                <source src="{{ $src }}" type="video/mp4">
+                Your browser doesn't support mp4 video. :(
+            </video>
+        {{ else }}
+            <a href="{{ $src }}" title="{{ $subtitle }}">
+                <img src="{{ $src }}" alt="{{ $subtitle }}">
+            </a>
+        {{ end }}
+    </div>
+    {{ end }}
+</div>
+
+{{ if $title }}
+<p class="has-text-centered is-italic has-text-grey-light">{{ $title }}</p>
+{{ end }}


### PR DESCRIPTION
Syntax:

```
{{< single-title-imgs
    "Dank memes"
    "https://via.placeholder.com/350x150|Before (Colors are wrong)"
    "https://via.placeholder.com/350x150|After (fixed)"
>}}
```

On various design decisions:

- Additional CSS is needed, as Bulma adds unwanted padding, and wrangling columns to get them to work correctly is going to be a bigger hack.
- Separate shortcode simply for reasons of simplicity of interface.

Example:

![idea64-10-09-2018_19-24-44](https://user-images.githubusercontent.com/1404334/45293225-e173e680-b53a-11e8-8ac0-2024e348c1fb.png)

Subtitles are shown in full screen previews.